### PR TITLE
fix: migrate chatbot to async OpenAI client and fix rate limit window

### DIFF
--- a/chatboat/src/domain/application.py
+++ b/chatboat/src/domain/application.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import AsyncGenerator
 import yaml
 import random
 from pathlib import Path
@@ -31,7 +31,7 @@ class Application:
     def pick_random_suggestion(self) -> list[str]:
         return random.sample(self._suggestions, SUGGESTIONS_LIMIT)
 
-    def send_message(self, message:str, history: list) -> Generator[str, None, None]:
+    def send_message(self, message:str, history: list) -> AsyncGenerator[str, None]:
         if not message:
             raise ValueError("Message cannot be empty")
         data = self._data

--- a/chatboat/src/domain/openai_client.py
+++ b/chatboat/src/domain/openai_client.py
@@ -1,15 +1,15 @@
-from typing import Generator
-from openai import OpenAI
+from typing import AsyncGenerator
+from openai import AsyncOpenAI
 
 MODEL_TIMEOUT_SECONDS = 15
 MAX_OUTPUT_TOKENS = 500
 
 class OpenAIClient:
     def __init__(self) -> None:
-        self._client = OpenAI()
+        self._client = AsyncOpenAI()
 
-    def send_message(self, message:str, data:str, history: list) -> Generator[str, None, None]:
-        stream = self._client.chat.completions.create(
+    async def send_message(self, message:str, data:str, history: list) -> AsyncGenerator[str, None]:
+        stream = await self._client.chat.completions.create(
             model="gpt-4o-mini-2024-07-18",
             max_tokens=MAX_OUTPUT_TOKENS,
             timeout=MODEL_TIMEOUT_SECONDS,
@@ -40,7 +40,7 @@ class OpenAIClient:
                 {"role": "user", "content": message}
             ]
         )
-        for chunk in stream:
+        async for chunk in stream:
             delta = chunk.choices[0].delta.content
             if delta:
                 yield delta

--- a/chatboat/src/domain/test/test_agent.py
+++ b/chatboat/src/domain/test/test_agent.py
@@ -1,14 +1,24 @@
+import asyncio
 from unittest.mock import MagicMock, patch
 
 from src.domain.openai_client import OpenAIClient
 
 def test_agent_send_message():
-    with patch("src.domain.openai_client.OpenAI") as mock_openai:
+    with patch("src.domain.openai_client.AsyncOpenAI") as mock_openai:
         mock_chunk = MagicMock()
         mock_chunk.choices[0].delta.content = "Hello"
-        mock_openai.return_value.chat.completions.create.return_value = iter([mock_chunk])
+
+        async def mock_create(*args, **kwargs):
+            async def async_stream():
+                yield mock_chunk
+            return async_stream()
+
+        mock_openai.return_value.chat.completions.create = mock_create
 
         agent = OpenAIClient()
-        result = list(agent.send_message("What are your skills?", "some fake data", []))
 
+        async def run():
+            return [chunk async for chunk in agent.send_message("What are your skills?", "some fake data", [])]
+
+        result = asyncio.run(run())
         assert result == ["Hello"]

--- a/chatboat/src/web/main.py
+++ b/chatboat/src/web/main.py
@@ -19,7 +19,8 @@ app = _build_webserver().get_app()
 reload = os.getenv("ENV", "production") != "production"
 
 def main() -> None:
-    uvicorn.run("src.web.main:app", host="0.0.0.0", port=int(os.getenv("PORT", 8000)), reload=reload)
+    workers = 1 if reload else 2
+    uvicorn.run("src.web.main:app", host="0.0.0.0", port=int(os.getenv("PORT", 8000)), reload=reload, workers=workers)
 
 if __name__ == "__main__":
     main()

--- a/chatboat/src/web/routes/chatboat.py
+++ b/chatboat/src/web/routes/chatboat.py
@@ -1,3 +1,5 @@
+import time
+
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from fastapi.responses import StreamingResponse
@@ -7,6 +9,7 @@ from src.domain.application import Application
 MAX_MESSAGES_PER_IP = 10
 MAX_MESSAGE_LENGTH = 400
 MAX_HISTORY_LENGTH = 8
+RATE_WINDOW_SECONDS = 3600
 
 class ChatRequest(BaseModel):
     message: str
@@ -28,7 +31,7 @@ class ChatBoatRoutes:
     def get_random_suggestions(self) -> dict:
         return {"suggestions": self._application.pick_random_suggestion()}
 
-    def send_message(self, request: Request, body: ChatRequest) -> StreamingResponse:
+    async def send_message(self, request: Request, body: ChatRequest) -> StreamingResponse:
         client_ip = self._get_client_ip(request)
         self._enforce_rate_limit(client_ip)
         self._validate_message(body.message)
@@ -48,6 +51,12 @@ class ChatBoatRoutes:
         return request.client.host if request.client else "unknown"
 
     def _enforce_rate_limit(self, client_ip: str) -> None:
+        now = time.time()
+        last_reset = self._ip_last_sent_at.get(client_ip, 0)
+        if now - last_reset >= RATE_WINDOW_SECONDS:
+            self._ip_message_counts[client_ip] = 0
+            self._ip_last_sent_at[client_ip] = now
+
         count = self._ip_message_counts.get(client_ip, 0)
         if count >= MAX_MESSAGES_PER_IP:
             raise HTTPException(

--- a/chatboat/src/web/test/test_chatboat.py
+++ b/chatboat/src/web/test/test_chatboat.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 from fastapi import HTTPException
 
@@ -22,7 +23,7 @@ def test_send_message():
     mock_request.client.host = "127.0.0.1"
     body = ChatRequest(message="hello", history=[])
 
-    result = routes.send_message(mock_request, body)
+    result = asyncio.run(routes.send_message(mock_request, body))
 
     mock_app.send_message.assert_called_once_with("hello", [])
     assert result.status_code == 200
@@ -45,7 +46,7 @@ def test_send_message_rejects_long_message():
     body = ChatRequest(message="a" * 401, history=[])
 
     with pytest.raises(HTTPException) as exc:
-        routes.send_message(mock_request, body)
+        asyncio.run(routes.send_message(mock_request, body))
 
     assert exc.value.status_code == 400
     assert exc.value.detail == "Message too long"
@@ -59,11 +60,13 @@ def test_send_message_rejects_when_rate_limit_reached(monkeypatch):
     mock_request.client.host = "127.0.0.1"
     body = ChatRequest(message="hello", history=[])
 
-    for _ in range(chatboat.MAX_MESSAGES_PER_IP):
-        routes.send_message(mock_request, body)
+    async def exhaust_limit():
+        for _ in range(chatboat.MAX_MESSAGES_PER_IP):
+            await routes.send_message(mock_request, body)
+        await routes.send_message(mock_request, body)
 
     with pytest.raises(HTTPException) as exc:
-        routes.send_message(mock_request, body)
+        asyncio.run(exhaust_limit())
 
     assert exc.value.status_code == 429
     assert exc.value.detail["message"] == "Message limit reached"
@@ -82,6 +85,6 @@ def test_send_message_trims_history():
         history=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     )
 
-    routes.send_message(mock_request, body)
+    asyncio.run(routes.send_message(mock_request, body))
 
     mock_app.send_message.assert_called_once_with("hello", [3, 4, 5, 6, 7, 8, 9, 10])


### PR DESCRIPTION
- Replace OpenAI sync client with AsyncOpenAI to avoid blocking the event loop
- Add 1-hour sliding window to rate limiter (previously counted forever)
- Make /chat route async to match async generator pipeline
- Run 2 uvicorn workers in production
- Update tests to use asyncio.run and async mocks